### PR TITLE
Added Rule-Based Renovation Extractor 

### DIFF
--- a/src/renovation_tracker/main.py
+++ b/src/renovation_tracker/main.py
@@ -1,5 +1,37 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import Any, Dict
+
+from renovation_tracker.nlp_predict import extract_renovations
+
+
+class PredictRequest(BaseModel):
+    description: str
+
+
+class PredictResponse(BaseModel):
+    result: Dict[str, Any]
+
+
+app = FastAPI(title="Renovation Tracker API")
+
+
+@app.get("/", tags=["health"])
+def health():
+    return {"status": "ok"}
+
+
+@app.post("/predict-renovations", response_model=PredictResponse)
+def predict_renovations(req: PredictRequest):
+    """Accepts a property description and returns structured renovation info."""
+    result = extract_renovations(req.description)
+    return {"result": result}
+
+
 def main():
-    print("Hello from renovation-tracker-backend!")
+    print("This module exposes a FastAPI app. Run with: uvicorn renovation_tracker.main:app --reload")
 
 
 if __name__ == "__main__":

--- a/src/renovation_tracker/nlp_predict.py
+++ b/src/renovation_tracker/nlp_predict.py
@@ -1,0 +1,136 @@
+# Victoria Castagnola
+#
+# This is a simple script to predict the category of a room using a pre-trained NLP model.
+# It takes in the predicted input and returns the predicted output.
+# docker file that manages dependencies and environment is needed, include instructions in readme if needed
+#Tools needed: yolo, darknet, potentially other NLP libraries
+#use virtual environment if needed click the bottom part where it says the number
+"""nlp_predict -- simple, rule-based extractor for renovated parts of a property.
+
+This module provides a lightweight `extract_renovations(text)` function that scans
+property descriptions for renovation mentions and returns a structured object
+describing which parts were renovated, details, and a simple confidence score.
+
+The implementation is intentionally rule-based (keyword + sentence extraction)
+so it works without any heavy ML dependencies and is easy to extend.
+"""
+from __future__ import annotations
+
+import re
+from typing import Dict, List, Tuple
+from datetime import datetime
+
+RENOVATION_CATEGORIES: Dict[str, List[str]] = {
+    "kitchen": ["kitchen", "cabinets", "countertop", "countertops", "island"],
+    "bathroom": ["bathroom", "bath", "shower", "vanity", "toilet"],
+    "roof": ["roof", "re-roof", "re roof", "shingles"],
+    "windows": ["window", "windows", "skylight", "double pane", "double-pane"],
+    "flooring": ["floor", "flooring", "hardwood", "laminate", "tile", "carpet"],
+    "plumbing": ["plumb", "plumbing", "pipes", "drain"],
+    "electrical": ["electrical", "wiring", "wires", "outlets", "panel"],
+    "hvac": ["hvac", "heating", "air conditioning", "ac", "furnace", "boiler"],
+    "exterior": ["exterior", "siding", "painted exterior", "facade", "façade"],
+    "basement": ["basement", "finished basement", "unfinished basement"],
+    "landscaping": ["landscape", "landscaping", "yard", "garden", "fence"],
+    "doors": ["door", "doors", "front door", "storm door"],
+    "gutters": ["gutter", "gutters"],
+    "foundation": ["foundation", "footings", "crawl space"],
+    "attic": ["attic", "insulation"],
+}
+
+STRONG_VERBS = ["renovated", "remodeled", "rebuilt", "replaced", "installed", "refinished", "gut rehab", "gut-rehab"]
+MEDIUM_VERBS = ["updated", "updated", "refreshed", "upgraded", "modernized"]
+
+
+def _find_sentences_with_keywords(text: str, keywords: List[str]) -> List[str]:
+    text_lower = text.lower()
+    sentences = re.split(r"(?<=[.!?])\s+", text.strip())
+    matches: List[str] = []
+    for s in sentences:
+        s_l = s.lower()
+        for kw in keywords:
+            if kw in s_l:
+                matches.append(s.strip())
+                break
+    return matches
+
+
+def _estimate_confidence(sentence: str) -> float:
+    s = sentence.lower()
+    for strong in STRONG_VERBS:
+        if strong in s:
+            return 0.92
+    for med in MEDIUM_VERBS:
+        if med in s:
+            return 0.75
+    # weak signals like "painted" or "new" alone are lower
+    if "new" in s or "brand new" in s:
+        return 0.85
+    return 0.6
+
+
+def extract_renovations(text: str) -> Dict[str, object]:
+    """Extract renovation mentions from a property description.
+
+    Returns a dictionary with:
+      - items: list of {name, renovated(bool), details(list[str]), confidence(float)}
+      - summary: list of names detected
+      - raw_text: original text
+      - generated_at: ISO timestamp
+    """
+    if not text or not text.strip():
+        return {
+            "items": [],
+            "summary": [],
+            "raw_text": text,
+            "generated_at": datetime.utcnow().isoformat() + "Z",
+        }
+
+    items = []
+    detected = []
+
+    for name, keywords in RENOVATION_CATEGORIES.items():
+        sentences = _find_sentences_with_keywords(text, keywords + [name])
+        if sentences:
+            # dedupe and keep up to 3 details
+            uniq = []
+            for s in sentences:
+                if s not in uniq:
+                    uniq.append(s)
+                if len(uniq) >= 3:
+                    break
+            confidences = [_estimate_confidence(s) for s in uniq]
+            confidence = max(confidences) if confidences else 0.6
+            items.append({
+                "name": name,
+                "renovated": True,
+                "details": uniq,
+                "confidence": round(confidence, 2),
+            })
+            detected.append(name)
+        else:
+            items.append({
+                "name": name,
+                "renovated": False,
+                "details": [],
+                "confidence": 0.0,
+            })
+
+    result = {
+        "items": items,
+        "summary": detected,
+        "raw_text": text,
+        "generated_at": datetime.utcnow().isoformat() + "Z",
+    }
+    return result
+
+
+if __name__ == "__main__":
+    # quick manual smoke test
+    sample = (
+        "The kitchen was completely renovated in 2022 with new cabinets and countertops. "
+        "Bathrooms were updated, the roof was replaced last year and new windows were installed."
+    )
+    import json
+
+    print(json.dumps(extract_renovations(sample), indent=2))


### PR DESCRIPTION
Small, rule-based API that ingests a property description and returns a structured list of which parts of the property appear renovated (category, example sentences, and a simple confidence score). Very basic framework.

What changed:

nlp_predict.py — added extract_renovations(text) (keyword + sentence extraction, small confidence heuristic). 
main.py — added FastAPI endpoint POST /predict-renovations with simple request/response models.

Potential Next Steps:
Incorporate ML into extractions of renovations for more accurate feedback
Refine keywords and renovation categories further (manual, may take a while)